### PR TITLE
Harden authentication flows

### DIFF
--- a/app/Http/Controllers/Auth/SessionController.php
+++ b/app/Http/Controllers/Auth/SessionController.php
@@ -4,22 +4,42 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 
 class SessionController extends Controller
 {
     public function login(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'email'    => ['required','email'],
-            'password' => ['required','string'],
-            'remember' => ['sometimes','boolean'],
+            'email'    => ['required', 'email'],
+            'password' => ['required', 'string'],
+            'remember' => ['sometimes', 'boolean'],
         ]);
 
-        if (! Auth::attempt(['email' => $validated['email'], 'password' => $validated['password']], $request->boolean('remember'))) {
+        if (! Auth::attempt(
+            ['email' => $validated['email'], 'password' => $validated['password']],
+            $request->boolean('remember')
+        )) {
             return response()->json(['message' => 'Invalid credentials.'], 422);
+        }
+
+        $user = Auth::user();
+
+        if ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            $exception = ValidationException::withMessages([
+                'email' => ['Email verification required.'],
+            ]);
+            $exception->status = 403;
+
+            throw $exception;
         }
 
         $request->session()->regenerate();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,15 +2,17 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, MustVerifyEmailTrait, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Event::listen(
+            Registered::class,
+            SendEmailVerificationNotification::class,
+        );
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\EventServiceProvider::class,
+    App\Providers\FortifyServiceProvider::class,
 ];

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -146,7 +146,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,10 +16,14 @@ Route::get('/health', fn () => ['ok' => true])->name('health');
 Route::prefix('auth')->group(function () {
     // Registration + login
     Route::post('/register', [RegisterController::class, 'store'])->name('auth.register');
-    Route::post('/login', [LoginController::class, 'password'])->name('auth.login');
+    Route::post('/login', [LoginController::class, 'password'])
+        ->middleware('throttle:login')
+        ->name('auth.login');
 
     // Cookie session login/logout (for SPA same-site)
-    Route::post('/session/login', [SessionController::class, 'login'])->name('auth.session.login');
+    Route::post('/session/login', [SessionController::class, 'login'])
+        ->middleware('throttle:login')
+        ->name('auth.session.login');
     Route::post('/session/logout', [SessionController::class, 'logout'])->name('auth.session.logout');
 
     // Magic link (stubs)


### PR DESCRIPTION
## Summary
- enable Sanctum token support and email verification requirements on the User model
- block session and token logins for unverified accounts while throttling password-based endpoints
- register Fortify and event providers so verification notifications are dispatched

## Testing
- APP_KEY=base64:/rE/kMq8k8z3lQ/YFB2r5RNx1/wr9SK9GCXnOFJ7DfA= php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d60e989c608329bffd5eae8aa2a29b